### PR TITLE
Workaround for networked filesystems on Windows (nodejs/node#48530)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,21 @@ class CoverageInstrumenter {
 
     await this.postSession('Profiler.disable');
 
+    // When using networked filesystems on Windows, v8 sometimes returns URLs
+    // of the form file:////<host>/path. These URLs are not well understood
+    // by NodeJS (see https://github.com/nodejs/node/issues/48530).
+    // We circumvent this issue here by fixing these URLs.
+    // FWIW, Python has special code to deal with URLs like this
+    // https://github.com/python/cpython/blob/bef1c8761e3b0dfc5708747bb646ad8b669cbd67/Lib/nturl2path.py#L22C1-L22C1
+    if (process.platform === 'win32') {
+      const prefix = 'file:////';
+      result.forEach(res => {
+        if (res.url.startsWith(prefix)) {
+          res.url = 'file://' + res.url.slice(prefix.length);
+        }
+      })
+    }
+
     return result;
   }
 }


### PR DESCRIPTION
When using networked filesystems on Windows, V8 sometimes returns URLs that look like `file:////<host>/path`. Given that these URLs are well understood by [Python](https://github.com/python/cpython/blob/bef1c8761e3b0dfc5708747bb646ad8b669cbd67/Lib/nturl2path.py#L22C1-L22C1), Windows Explorer and Chrome, this is presumably not a bug in V8. On the other hand, NodeJS does not parse these correctly (nodejs/node#48530) and it ends up throwing instead.

```
 FAIL  ndl1/test/index.test.ts
  ● Test suite failed to run

    TypeError: File URL path must be absolute

      at N:/ndl1/node_modules/jest-runtime/build/index.js:1400:59
          at Array.map (<anonymous>)

```
 